### PR TITLE
Ci continue if tier2 fails

### DIFF
--- a/.github/workflows/build-bsp.yml
+++ b/.github/workflows/build-bsp.yml
@@ -68,12 +68,13 @@ jobs:
   check:
     runs-on: ubuntu-latest
     needs: [setup, build]
+    name: Check tier 1 BSPs built on stable
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           path: successful-jobs
-      - name: Tier 1 BSPs built on stable
+      - name: Do checks
         env:
           MATRIX: ${{ needs.setup.outputs.matrix }}
         run: |


### PR DESCRIPTION
# Summary
[describe your changes here]

# Checklist
  - [ ] `CHANGELOG.md` for the BSP or HAL updated
  - [ ] All new or modified code is well documented, especially public items
  - [ ] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 

## If Adding a new Board
  - [ ] Board CI added to `crates.json`
  - [ ] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"

## If Adding a new cargo `feature` to the HAL
  - [ ] Feature is added to the test matrix for applicable boards / PACs in `crates.json`
