### PR TITLE
Unify ADC setup (Remove V1 clock setup)

### DIFF
--- a/hal/src/peripherals/adc/builder.rs
+++ b/hal/src/peripherals/adc/builder.rs
@@ -245,7 +245,6 @@ impl AdcBuilder {
     }
 
     /// Turn the builder into an ADC
-    #[hal_cfg("adc-d5x")]
     #[inline]
     pub fn enable<I: AdcInstance, PS: crate::clock::v2::pclk::PclkSourceId>(
         self,
@@ -255,17 +254,5 @@ impl AdcBuilder {
     ) -> Result<Adc<I>, BuilderError> {
         let settings = self.to_settings()?;
         Adc::new(adc, settings, clk, pclk).map_err(|e| e.into())
-    }
-
-    #[hal_cfg(any("adc-d11", "adc-d21"))]
-    #[inline]
-    pub fn enable<I: AdcInstance>(
-        self,
-        adc: I::Instance,
-        pm: &mut crate::pac::Pm,
-        clock: &crate::clock::AdcClock,
-    ) -> Result<Adc<I>, BuilderError> {
-        let settings = self.to_settings()?;
-        Adc::new(adc, settings, pm, clock).map_err(|e| e.into())
     }
 }

--- a/hal/src/peripherals/adc/d11/mod.rs
+++ b/hal/src/peripherals/adc/d11/mod.rs
@@ -22,17 +22,14 @@ impl PrimaryAdc for Adc0 {}
 impl AdcInstance for Adc0 {
     type Instance = pac::Adc;
 
+    type ClockId = crate::clock::v2::pclk::ids::Adc0;
+
     #[cfg(feature = "async")]
     type Interrupt = crate::async_hal::interrupts::ADC;
 
     #[inline]
     fn peripheral_reg_block(p: &mut Peripherals) -> &pac::adc::RegisterBlock {
         &p.adc
-    }
-
-    #[inline]
-    fn enable_pm(pm: &mut pac::Pm) {
-        pm.apbcmask().modify(|_, w| w.adc_().set_bit());
     }
 
     #[inline]

--- a/hal/src/peripherals/adc/mod.rs
+++ b/hal/src/peripherals/adc/mod.rs
@@ -140,13 +140,9 @@ pub trait AdcInstance {
     // The Adc0 and Adc1 PAC types implement Deref
     type Instance: Deref<Target = adc0::RegisterBlock>;
 
-    #[hal_cfg("adc-d5x")]
     type ClockId: crate::clock::v2::apb::ApbId + crate::clock::v2::pclk::PclkId;
 
     fn peripheral_reg_block(p: &mut Peripherals) -> &adc0::RegisterBlock;
-
-    #[hal_cfg(any("adc-d11", "adc-d21"))]
-    fn enable_pm(pm: &mut pac::Pm);
 
     fn calibrate(instance: &Self::Instance);
 
@@ -162,16 +158,6 @@ where
     const CHANNEL: u8;
 }
 
-/// ADC Instance
-#[hal_cfg(any("adc-d11", "adc-d21"))]
-pub struct Adc<I: AdcInstance> {
-    adc: I::Instance,
-    cfg: AdcSettings,
-    discard: bool,
-}
-
-/// ADC Instance
-#[hal_cfg("adc-d5x")]
 pub struct Adc<I: AdcInstance> {
     adc: I::Instance,
     _apbclk: crate::clock::v2::apb::ApbClk<I::ClockId>,
@@ -201,7 +187,6 @@ impl<I: AdcInstance> Adc<I> {
     ///
     /// NOTE: If you plan to run the chip above 100°C, then the maximum GCLK
     /// frequency for the ADC is restricted to 90Mhz for stable performance.
-    #[hal_cfg("adc-d5x")]
     #[inline]
     pub(crate) fn new<PS: crate::clock::v2::pclk::PclkSourceId>(
         adc: I::Instance,
@@ -226,36 +211,6 @@ impl<I: AdcInstance> Adc<I> {
         let mut new_adc = Self {
             adc,
             _apbclk: clk,
-            cfg: settings,
-            discard: true,
-        };
-        new_adc.configure(settings);
-        Ok(new_adc)
-    }
-
-    /// Construct a new ADC instance
-    ///
-    /// ## Important
-    ///
-    /// This function will return [Error::ClockTooFast] if the clock source
-    /// provided is faster than 48 MHz, since this is the maximum frequency
-    /// for the ADC as per the datasheet.
-    #[hal_cfg(any("adc-d11", "adc-d21"))]
-    #[inline]
-    pub(crate) fn new(
-        adc: I::Instance,
-        settings: AdcSettings,
-        pm: &mut pac::Pm,
-        clock: &crate::clock::AdcClock,
-    ) -> Result<Self, Error> {
-        if (clock.freq() as crate::time::Hertz).to_Hz() > 48_000_000 {
-            // Clock source is too fast
-            return Err(Error::ClockTooFast);
-        }
-
-        I::enable_pm(pm);
-        let mut new_adc = Self {
-            adc,
             cfg: settings,
             discard: true,
         };
@@ -412,16 +367,7 @@ impl<I: AdcInstance> Adc<I> {
         Ok(())
     }
 
-    /// Return the underlying ADC PAC object.
-    #[hal_cfg(any("adc-d11", "adc-d21"))]
-    #[inline]
-    pub fn free(mut self) -> I::Instance {
-        self.software_reset();
-        self.adc
-    }
-
     /// Return the underlying ADC PAC object and the enabled APB ADC clock.
-    #[hal_cfg("adc-d5x")]
     #[inline]
     pub fn free(mut self) -> (I::Instance, crate::clock::v2::apb::ApbClk<I::ClockId>) {
         self.software_reset();

--- a/hal/src/peripherals/adc/mod.rs
+++ b/hal/src/peripherals/adc/mod.rs
@@ -177,17 +177,18 @@ impl<I: AdcInstance> Adc<I> {
     /// ## Important
     ///
     /// This function will return `Err` if the clock source provided
-    /// is faster than 100 MHz, since this is the maximum frequency for
-    /// GCLK_ADCx as per the datasheet.
+    /// is faster than 100 MHz (D5x) or 48Mhz (D21/D11), since this
+    /// is the maximum frequency for GCLK_ADCx as per the datasheet.
     ///
     /// The [`new`](Self::new) function currently takes an `&` reference to a
     /// [`Pclk`](crate::clock::v2::pclk::Pclk). In the future this will likely
     /// change to taking full ownership of it; in the meantime, you must ensure
     /// that the PCLK is enabled for the `Adc` struct's lifetime.
     ///
-    /// NOTE: If you plan to run the chip above 100°C, then the maximum GCLK
+    /// NOTE (D5x specific): If you plan to run the chip above 100°C, then the maximum GCLK
     /// frequency for the ADC is restricted to 90Mhz for stable performance.
     #[inline]
+    #[atsamd_hal_macros::hal_macro_helper]
     pub(crate) fn new<PS: crate::clock::v2::pclk::PclkSourceId>(
         adc: I::Instance,
         settings: AdcSettings,
@@ -203,7 +204,13 @@ impl<I: AdcInstance> Adc<I> {
         // at the time of creation of the Adc struct; however we can't guarantee
         // that the clock will stay enabled for the duration of its lifetime.
 
+        #[hal_cfg("adc-d5x")]
         if pclk.freq() > fugit::HertzU32::from_raw(100_000_000) {
+            // Clock source is too fast
+            return Err(Error::ClockTooFast);
+        }
+        #[hal_cfg(any("adc-d21", "adc-d11"))]
+        if pclk.freq() > fugit::HertzU32::from_raw(48_000_000) {
             // Clock source is too fast
             return Err(Error::ClockTooFast);
         }


### PR DESCRIPTION
Referencing https://github.com/atsamd-rs/atsamd/issues/912

Removes the clocking V1 setup from the ADC peripheral, unifying the clock setup for both D5x and D2x.

Tested on D21, it works well.

Examples will be broken. I'll be fixing them soon. Will update this when the examples are fixed